### PR TITLE
Agregar detalle por coach en facturas

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ http://localhost/public/index.php?controller=facturas&action=generar
 ```
 Luego podrá revisar la sección **Facturas** para ver deudas y registrar pagos.
 
+Cada factura ahora incluye un desglose por entrenador en la tabla `facturas_coach`, permitiendo separar lo que corresponde pagar al club y a cada coach.
+
 ### Uso de la sección "Facturas"
 1. Ingrese al menú **Facturas** en la barra de navegación.
 2. Desde ahí podrá filtrar por apoderado, mes o estado, consultar el detalle y registrar pagos parciales o totales.

--- a/controllers/FacturaController.php
+++ b/controllers/FacturaController.php
@@ -2,6 +2,7 @@
 require_once 'Controller.php';
 require_once __DIR__.'/../models/Factura.php';
 require_once __DIR__.'/../models/Apoderado.php';
+require_once __DIR__.'/../models/FacturaCoach.php';
 
 class FacturaController extends Controller {
     public function index() {
@@ -27,8 +28,10 @@ class FacturaController extends Controller {
 
     public function show() {
         $model = new Factura();
+        $fcModel = new FacturaCoach();
         $factura = $model->find($_GET['id']);
-        $this->render('facturas/show', ['factura'=>$factura]);
+        $detalle = $fcModel->porFactura($_GET['id']);
+        $this->render('facturas/show', ['factura'=>$factura,'detalle'=>$detalle]);
     }
 
     public function registrarPago() {

--- a/models/Factura.php
+++ b/models/Factura.php
@@ -33,6 +33,16 @@ class Factura extends Model {
             if ($stmt->fetch()) { continue; }
             $stmt = $this->db->prepare("INSERT INTO facturas (apoderado_id, mes, año, monto_social, monto_clases, fecha_generacion) VALUES (?,?,?,?,?,?)");
             $stmt->execute([$row['apoderado_id'], $mes, $año, 3000, $row['monto_clases'], $fecha]);
+            $factura_id = $this->db->lastInsertId();
+
+            // detalle por coach
+            $detSql = "SELECT m.coach_id, SUM(m.tarifa) monto FROM deportistas d JOIN inscripciones i ON i.deportista_id=d.id JOIN modalidades m ON m.id=i.modalidad_id WHERE d.apoderado_id=? GROUP BY m.coach_id";
+            $detStmt = $this->db->prepare($detSql);
+            $detStmt->execute([$row['apoderado_id']]);
+            foreach ($detStmt->fetchAll(PDO::FETCH_ASSOC) as $det) {
+                $stmtDet = $this->db->prepare("INSERT INTO facturas_coach (factura_id, coach_id, monto_clases) VALUES (?,?,?)");
+                $stmtDet->execute([$factura_id, $det['coach_id'], $det['monto']]);
+            }
         }
     }
 

--- a/models/FacturaCoach.php
+++ b/models/FacturaCoach.php
@@ -1,0 +1,14 @@
+<?php
+require_once 'Model.php';
+
+class FacturaCoach extends Model {
+    protected $table = 'facturas_coach';
+
+    public function porFactura($factura_id) {
+        $sql = "SELECT fc.*, c.nombre AS coach FROM facturas_coach fc JOIN coaches c ON fc.coach_id = c.id WHERE fc.factura_id = ?";
+        $stmt = $this->db->prepare($sql);
+        $stmt->execute([$factura_id]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
+}
+?>

--- a/schema.sql
+++ b/schema.sql
@@ -62,5 +62,15 @@ CREATE TABLE facturas (
   FOREIGN KEY (apoderado_id) REFERENCES apoderados(id)
 );
 
+-- detalle de cada factura por coach
+CREATE TABLE facturas_coach (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  factura_id INT NOT NULL,
+  coach_id INT NOT NULL,
+  monto_clases DECIMAL(10,2) NOT NULL,
+  FOREIGN KEY (factura_id) REFERENCES facturas(id) ON DELETE CASCADE,
+  FOREIGN KEY (coach_id) REFERENCES coaches(id) ON DELETE CASCADE
+);
+
 -- insertar coaches iniciales
 INSERT INTO coaches (nombre) VALUES ('Freeskating'), ('Danza & Flex');

--- a/views/facturas/show.php
+++ b/views/facturas/show.php
@@ -7,6 +7,17 @@
 <tr><th>Saldo</th><td><?= $factura['saldo'] ?></td></tr>
 <tr><th>Estado</th><td><?= $factura['estado'] ?></td></tr>
 </table>
+
+<h4>Detalle por Entrenador</h4>
+<table class="table table-bordered">
+<tr><th>Entrenador</th><th>Monto Clases</th></tr>
+<?php foreach($detalle as $d): ?>
+<tr>
+  <td><?= $d['coach'] ?></td>
+  <td><?= $d['monto_clases'] ?></td>
+</tr>
+<?php endforeach; ?>
+</table>
 <h4>Registrar Pago</h4>
 <form method="post" action="./?controller=facturas&action=registrarPago">
   <input type="hidden" name="factura_id" value="<?= $factura['id'] ?>">


### PR DESCRIPTION
## Summary
- registrar detalle de facturas por entrenador
- mostrar desglose en la vista de facturas
- actualizar esquema de base de datos y documentación

## Testing
- `php -l models/Factura.php`
- `php -l models/FacturaCoach.php`
- `php -l controllers/FacturaController.php`
- `php -l views/facturas/show.php`


------
https://chatgpt.com/codex/tasks/task_b_6871834c2ad083259c29a66737b5fec4